### PR TITLE
Re-export ratatui as part of the library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,4 @@ pub use self::parser::types::*;
 pub use app::App;
 pub use event::Event;
 pub use tui::Tui;
+pub use ratatui;


### PR DESCRIPTION
Since this library expects ratatui structs as inputs, let's re-export the underlying ratatui dependency. This allows for multiple ratatui versions to coexist in dependant crate